### PR TITLE
fix: replace docs with gh-page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   # Publish Documentation Job
   publish-docs:
     needs: run-lint
-    if: github.event_name == 'push' && github.ref == 'refs/heads/docs'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/gh-pages'
     uses: ./.github/workflows/publish_docs.yml
     with:
       python-version: '3.12'


### PR DESCRIPTION
Changing docs branch to gh-pages since its in the way of conventional commits. 